### PR TITLE
Add Kafka integration with Docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+KAFKA_BROKER=localhost:9092
+KAFKA_CLIENT_ID=test-ai
+KAFKA_GROUP_ID=test-ai-group

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ npm run start
 ```
 
 The application will listen on http://localhost:3000 by default.
+
+## Docker Compose
+
+A `docker-compose.yml` is provided to run the application together with Kafka. Run:
+
+```bash
+docker-compose up --build
+```
+
+The app will be available on port `3000` and Kafka will listen on `localhost:9092`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  app:
+    build: .
+    depends_on:
+      - kafka
+    environment:
+      PORT: 3000
+      KAFKA_BROKER: kafka:9092
+      KAFKA_CLIENT_ID: test-ai
+      KAFKA_GROUP_ID: test-ai-group
+    ports:
+      - "3000:3000"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@nestjs/microservices": "^10.0.0",
+    "@nestjs/config": "^3.0.0",
+    "kafkajs": "^2.6.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,31 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { KafkaService } from './kafka/kafka.service';
+import { KafkaConsumer } from './kafka/kafka.consumer';
 
 @Module({
-  imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    ClientsModule.register([
+      {
+        name: 'KAFKA_SERVICE',
+        transport: Transport.KAFKA,
+        options: {
+          client: {
+            clientId: process.env.KAFKA_CLIENT_ID,
+            brokers: [process.env.KAFKA_BROKER],
+          },
+          consumer: {
+            groupId: process.env.KAFKA_GROUP_ID || 'test-group',
+          },
+        },
+      },
+    ]),
+  ],
+  controllers: [AppController, KafkaConsumer],
+  providers: [AppService, KafkaService],
 })
 export class AppModule {}

--- a/src/dto/test.dto.ts
+++ b/src/dto/test.dto.ts
@@ -1,0 +1,3 @@
+export interface TestDto {
+  name: string;
+}

--- a/src/kafka/kafka.consumer.ts
+++ b/src/kafka/kafka.consumer.ts
@@ -1,0 +1,13 @@
+import { Controller, Logger } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { TestDto } from '../dto/test.dto';
+
+@Controller()
+export class KafkaConsumer {
+  private readonly logger = new Logger(KafkaConsumer.name);
+
+  @MessagePattern('internal.test')
+  handleMessage(@Payload() message: TestDto) {
+    this.logger.log(`Received message: ${JSON.stringify(message)}`);
+  }
+}

--- a/src/kafka/kafka.service.ts
+++ b/src/kafka/kafka.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { ClientKafka } from '@nestjs/microservices';
+import { lastValueFrom } from 'rxjs';
+
+@Injectable()
+export class KafkaService {
+  constructor(@Inject('KAFKA_SERVICE') private readonly client: ClientKafka) {}
+
+  async send(name: string) {
+    await lastValueFrom(this.client.emit('internal.test', { name }));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,24 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.KAFKA,
+    options: {
+      client: {
+        clientId: process.env.KAFKA_CLIENT_ID,
+        brokers: [process.env.KAFKA_BROKER],
+      },
+      consumer: {
+        groupId: process.env.KAFKA_GROUP_ID || 'test-group',
+      },
+    },
+  });
+
+  await app.startAllMicroservices();
+  await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- configure Kafka connection via `@nestjs/microservices`
- add Kafka producer service and consumer controller
- load configuration from environment variables
- provide docker-compose with Kafka and app services
- add example env file and basic Dockerfile
- document how to run with docker-compose

## Testing
- `npm run build` *(fails: Cannot find module '@nestjs/common' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684fb83e47a48330be9b18f58618e84f