### PR TITLE
Add users endpoints with postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,28 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
   app:
     build: .
     depends_on:
       - kafka
+      - postgres
     environment:
       PORT: 3000
       KAFKA_BROKER: kafka:9092
       KAFKA_CLIENT_ID: test-ai
       KAFKA_GROUP_ID: test-ai-group
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: user
+      DB_PASS: pass
+      DB_NAME: app
     ports:
       - "3000:3000"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.*\.spec\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['src/**/*.(t|j)s'],
+  coverageDirectory: './coverage',
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Base Nest.js project",
   "scripts": {
     "start": "ts-node src/main.ts",
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "test": "jest"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -13,12 +14,20 @@
     "rxjs": "^7.8.1",
     "@nestjs/microservices": "^10.0.0",
     "@nestjs/config": "^3.0.0",
-    "kafkajs": "^2.6.2"
+    "kafkajs": "^2.6.2",
+    "@nestjs/typeorm": "^10.0.0",
+    "typeorm": "^0.3.19",
+    "pg": "^8.8.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.2.0",
     "@types/node": "^20.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@nestjs/testing": "^10.0.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './users/user.entity';
+import { UsersModule } from './users/users.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { KafkaService } from './kafka/kafka.service';
@@ -9,6 +12,16 @@ import { KafkaConsumer } from './kafka/kafka.consumer';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT) || 5432,
+      username: process.env.DB_USER,
+      password: process.env.DB_PASS,
+      database: process.env.DB_NAME,
+      entities: [User],
+      synchronize: true,
+    }),
     ClientsModule.register([
       {
         name: 'KAFKA_SERVICE',
@@ -24,6 +37,7 @@ import { KafkaConsumer } from './kafka/kafka.consumer';
         },
       },
     ]),
+    UsersModule,
   ],
   controllers: [AppController, KafkaConsumer],
   providers: [AppService, KafkaService],

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,3 @@
+export class CreateUserDto {
+  name: string;
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post, Body, Query } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  create(@Body() dto: CreateUserDto) {
+    return this.usersService.create(dto);
+  }
+
+  @Get()
+  findAll(
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number,
+  ) {
+    return this.usersService.findAll(Number(limit) || 10, Number(offset) || 0);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { User } from './user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UsersService } from './users.service';
+import { User } from './user.entity';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let repo: Repository<User>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get(UsersService);
+    repo = module.get(getRepositoryToken(User));
+  });
+
+  it('should create user', async () => {
+    const saveSpy = jest.spyOn(repo, 'save').mockResolvedValue({ id: 1, name: 'test' } as User);
+    const result = await service.create({ name: 'test' });
+    expect(saveSpy).toHaveBeenCalled();
+    expect(result.name).toBe('test');
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './user.entity';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(@InjectRepository(User) private repo: Repository<User>) {}
+
+  create(dto: CreateUserDto) {
+    const user = this.repo.create(dto);
+    return this.repo.save(user);
+  }
+
+  findAll(limit = 10, offset = 0) {
+    return this.repo.find({ skip: offset, take: limit });
+  }
+}

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,44 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../src/users/users.module';
+import { User } from '../src/users/user.entity';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [User],
+          synchronize: true,
+        }),
+        UsersModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/users (POST) and (GET)', async () => {
+    await request(app.getHttpServer())
+      .post('/users')
+      .send({ name: 'john' })
+      .expect(201);
+
+    const res = await request(app.getHttpServer())
+      .get('/users?limit=1&offset=0')
+      .expect(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].name).toBe('john');
+  });
+});


### PR DESCRIPTION
## Summary
- configure TypeORM with Postgres
- add Users module with controller, service and entity
- expose GET/POST `/users` with pagination
- add Docker Compose Postgres service and environment
- add unit and integration tests
- configure Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684fb9cca88c8330888168e478ac478c